### PR TITLE
fix: 修复备忘录组件的实时同步、配置修改回退问题

### DIFF
--- a/backend/handlers/widget_version.go
+++ b/backend/handlers/widget_version.go
@@ -1,0 +1,194 @@
+package handlers
+
+import (
+	"flatnasgo-backend/config"
+	"flatnasgo-backend/models"
+	"flatnasgo-backend/utils"
+	"net/http"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Widget 保存的全局锁，防止并发写入冲突
+var widgetSaveMutex sync.Mutex
+
+// SaveWidgetRequest 保存 Widget 的请求
+type SaveWidgetRequest struct {
+	Data    interface{} `json:"data"`
+	Version int         `json:"version"`
+}
+
+// SaveWidgetWithVersion 带版本控制的保存 Widget 数据
+func SaveWidgetWithVersion(c *gin.Context) {
+	username := c.GetString("username")
+	if username == "" {
+		username = "admin"
+	}
+
+	widgetID := c.Param("id")
+
+	// 解析请求
+	var req SaveWidgetRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request format"})
+		return
+	}
+
+	// 获取系统配置
+	var sysConfig models.SystemConfig
+	utils.ReadJSON(config.SystemConfigFile, &sysConfig)
+
+	// 确定用户数据文件
+	userFile := filepath.Join(config.UsersDir, username+".json")
+	if username == "admin" && sysConfig.AuthMode == "single" {
+		userFile = filepath.Join(config.DataDir, "data.json")
+	}
+
+	// 使用全局锁保护文件操作
+	widgetSaveMutex.Lock()
+	defer widgetSaveMutex.Unlock()
+
+	// 读取当前用户数据
+	var userData map[string]interface{}
+	if err := utils.ReadJSON(userFile, &userData); err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "User data not found"})
+		return
+	}
+
+	// 获取 widgets 列表
+	widgets, ok := userData["widgets"].([]interface{})
+	if !ok {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Invalid widgets data structure"})
+		return
+	}
+
+	// 查找目标 widget
+	var targetWidget map[string]interface{}
+	var targetIndex int = -1
+
+	for i, w := range widgets {
+		if widgetMap, ok := w.(map[string]interface{}); ok {
+			if wId, ok := widgetMap["id"].(string); ok && wId == widgetID {
+				targetWidget = widgetMap
+				targetIndex = i
+				break
+			}
+		}
+	}
+
+	if targetIndex == -1 {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Widget not found"})
+		return
+	}
+
+	// 获取服务器端当前版本号
+	serverVersion := 0
+	if v, ok := targetWidget["version"].(float64); ok {
+		serverVersion = int(v)
+	}
+
+	// Last-Write-Wins：最新保存总是生效
+	// 版本号仅用于前端判断是否是更新的数据，不阻止保存
+
+	// 更新 widget 数据
+	targetWidget["data"] = req.Data
+	targetWidget["version"] = serverVersion + 1
+	targetWidget["updatedAt"] = time.Now().Unix()
+
+	// 更新列表
+	widgets[targetIndex] = targetWidget
+	userData["widgets"] = widgets
+
+	// 保存到文件
+	if err := utils.WriteJSON(userFile, userData); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save data"})
+		return
+	}
+
+	// 清除缓存
+	getDataCacheMu.Lock()
+	delete(getDataCache, username)
+	getDataCacheMu.Unlock()
+
+	// 通过 Socket.IO 广播更新（如果已连接）
+	if socketServer != nil {
+		socketServer.BroadcastToRoom("/", "user:"+username, "memo:updated", gin.H{
+			"widgetId": widgetID,
+			"content":  req.Data,
+		})
+	}
+
+	// 返回成功响应
+	c.JSON(http.StatusOK, gin.H{
+		"success":   true,
+		"id":        widgetID,
+		"version":   serverVersion + 1,
+		"updatedAt": targetWidget["updatedAt"],
+		"data":      req.Data,
+	})
+}
+
+// GetWidgetWithVersion 获取带版本号的 Widget
+func GetWidgetWithVersion(c *gin.Context) {
+	username := c.GetString("username")
+	if username == "" {
+		username = "admin"
+	}
+
+	widgetID := c.Param("id")
+
+	// 获取系统配置
+	var sysConfig models.SystemConfig
+	utils.ReadJSON(config.SystemConfigFile, &sysConfig)
+
+	// 确定用户数据文件
+	userFile := filepath.Join(config.UsersDir, username+".json")
+	if username == "admin" && sysConfig.AuthMode == "single" {
+		userFile = filepath.Join(config.DataDir, "data.json")
+	}
+
+	// 读取用户数据
+	var userData map[string]interface{}
+	if err := utils.ReadJSON(userFile, &userData); err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "User data not found"})
+		return
+	}
+
+	// 获取 widgets 列表
+	widgets, ok := userData["widgets"].([]interface{})
+	if !ok {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Invalid widgets data structure"})
+		return
+	}
+
+	// 查找目标 widget
+	for _, w := range widgets {
+		if widgetMap, ok := w.(map[string]interface{}); ok {
+			if wId, ok := widgetMap["id"].(string); ok && wId == widgetID {
+				version := 0
+				if v, ok := widgetMap["version"].(float64); ok {
+					version = int(v)
+				}
+
+				updatedAt := int64(0)
+				if t, ok := widgetMap["updatedAt"].(float64); ok {
+					updatedAt = int64(t)
+				}
+
+				c.JSON(http.StatusOK, gin.H{
+					"success":   true,
+					"id":        widgetID,
+					"data":      widgetMap["data"],
+					"version":   version,
+					"updatedAt": updatedAt,
+				})
+				return
+			}
+		}
+	}
+
+	c.JSON(http.StatusNotFound, gin.H{"error": "Widget not found"})
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -151,7 +151,11 @@ func main() {
 		api.GET("/docker-status", handlers.GetDockerStatus)                                        // Added Docker Status
 		api.GET("/docker/debug", handlers.GetDockerDebug)
 		api.GET("/config/proxy-status", handlers.GetProxyStatus)
-		api.GET("/widgets/:id", handlers.GetWidget) // Added Widget Data
+		api.GET("/widgets/:id", handlers.GetWidget) // Added Widget Data (deprecated, use version-controlled API)
+
+		// Version-controlled Widget API
+		api.GET("/widgets/v2/:id", middleware.AuthMiddleware(), handlers.GetWidgetWithVersion)   // 获取带版本号的 Widget
+		api.PUT("/widgets/v2/:id", middleware.AuthMiddleware(), handlers.SaveWidgetWithVersion) // 保存带版本号的 Widget
 
 		// Icon Routes
 		api.GET("/ali-icons", handlers.GetAliIcons)

--- a/backend/models/models.go
+++ b/backend/models/models.go
@@ -40,18 +40,20 @@ type Item struct {
 }
 
 type Widget struct {
-	ID       string                  `json:"id"`
-	Type     string                  `json:"type"`
-	Enable   bool                    `json:"enable"`
-	IsPublic bool                    `json:"isPublic"`
-	Data     any                     `json:"data"` // Flexible
-	Layouts  map[string]WidgetLayout `json:"layouts,omitempty"`
-	X        float64                 `json:"x,omitempty"`
-	Y        float64                 `json:"y,omitempty"`
-	W        float64                 `json:"w,omitempty"`
-	H        float64                 `json:"h,omitempty"`
-	ColSpan  float64                 `json:"colSpan,omitempty"`
-	RowSpan  float64                 `json:"rowSpan,omitempty"`
+	ID        string                  `json:"id"`
+	Type      string                  `json:"type"`
+	Enable    bool                    `json:"enable"`
+	IsPublic  bool                    `json:"isPublic"`
+	Data      any                     `json:"data"` // Flexible
+	Version   int                     `json:"version,omitempty"`   // 版本号，用于冲突检测
+	UpdatedAt int64                   `json:"updatedAt,omitempty"` // 更新时间戳
+	Layouts   map[string]WidgetLayout `json:"layouts,omitempty"`
+	X         float64                 `json:"x,omitempty"`
+	Y         float64                 `json:"y,omitempty"`
+	W         float64                 `json:"w,omitempty"`
+	H         float64                 `json:"h,omitempty"`
+	ColSpan   float64                 `json:"colSpan,omitempty"`
+	RowSpan   float64                 `json:"rowSpan,omitempty"`
 }
 
 type WidgetLayout struct {

--- a/frontend/src/components/MemoWidget.vue
+++ b/frontend/src/components/MemoWidget.vue
@@ -18,8 +18,7 @@ const editorRef = ref<InstanceType<typeof MemoEditor> | null>(null);
 const isEditing = ref(false);
 const localUpdatedAt = ref(0);
 const lastInputAt = ref(0);
-const isBroadcasting = ref(false);
-const isPageVisible = ref(document.visibilityState === "visible");
+const isSaving = ref(false); // 保存中标志，防止数据被覆盖
 
 // Persistence
 const { saveToIndexedDB, loadFromIndexedDB, status, progress, saveVersionSnapshot, loadVersions, deleteVersion } =
@@ -139,15 +138,45 @@ const buildPayload = () => ({
 
 let serverSaveTimer: ReturnType<typeof setTimeout> | null = null;
 let broadcastTimer: ReturnType<typeof setTimeout> | null = null;
-const ACTIVE_INPUT_WINDOW = 800;
-const POLL_ACTIVE_INTERVAL = 800;
-const POLL_IDLE_INTERVAL = 5000;
+
 const saveToServer = (immediate = false) => {
   if (!store.isLogged) return;
-  const doSave = () => {
+  const doSave = async () => {
+    isSaving.value = true;
     const payload = buildPayload();
     localUpdatedAt.value = payload.updatedAt;
-    store.saveWidget(props.widget.id, payload);
+    try {
+      // 使用新的版本控制API（Last-Write-Wins模式）
+      const response = await fetch(`/api/widgets/v2/${props.widget.id}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        credentials: 'include',
+        body: JSON.stringify({
+          data: payload,
+          version: 0, // Last-Write-Wins：版本号不重要
+        }),
+      });
+
+      if (response.ok) {
+        const result = await response.json();
+        // 通过 Socket.IO 通知其他设备
+        if (store.socket) {
+          store.socket.emit("memo:update", {
+            token: store.token || localStorage.getItem("flat-nas-token"),
+            widgetId: props.widget.id,
+            content: payload,
+          });
+        }
+      }
+    } catch (error) {
+      console.error('保存失败:', error);
+    } finally {
+      setTimeout(() => {
+        isSaving.value = false;
+      }, 500);
+    }
   };
 
   if (immediate) {
@@ -162,58 +191,40 @@ const saveToServer = (immediate = false) => {
   }, 800);
 };
 
+// Socket.IO 监听远程更新
 const applyRemotePayload = (payload: WidgetConfig["data"]) => {
   const parsed = parsePayload(payload);
   if (!parsed.content) return;
+
+  // 如果正在保存，忽略远程更新
+  if (isSaving.value) return;
+
+  // 如果正在编辑，忽略远程更新（避免打断用户）
   if (isEditing.value) return;
-  if (parsed.updatedAt && parsed.updatedAt <= localUpdatedAt.value) return;
-  if (parsed.content !== localData.value) {
-    localData.value = parsed.content;
-    mode.value = parsed.mode;
-    localUpdatedAt.value = parsed.updatedAt || Date.now();
-  }
-};
 
-const scheduleBroadcast = () => {
-  if (!isBroadcasting.value || !store.isLogged) return;
-  if (broadcastTimer) clearTimeout(broadcastTimer);
-  broadcastTimer = setTimeout(() => {
-    if (!isBroadcasting.value || !store.isLogged) return;
-    const payload = buildPayload();
-    store.socket?.emit("memo:update", {
-      token: store.token || localStorage.getItem("flat-nas-token"),
-      widgetId: props.widget.id,
-      content: payload,
-    });
-  }, 300);
-};
+  // 如果内容相同，不更新
+  if (parsed.content === localData.value && parsed.mode === mode.value) return;
 
-const updateSyncMode = () => {
-  const active =
-    isEditing.value && Date.now() - lastInputAt.value <= ACTIVE_INPUT_WINDOW;
-  const targetInterval = isPageVisible.value ? POLL_ACTIVE_INTERVAL : POLL_IDLE_INTERVAL;
-  if (active) {
-    if (pollTimer) {
-      clearInterval(pollTimer);
-      pollTimer = null;
-    }
-    isBroadcasting.value = true;
-  } else {
-    isBroadcasting.value = false;
-    if (!pollTimer) {
-      pollTimer = setInterval(pollRemote, targetInterval);
-    } else if (pollTimer && targetInterval !== currentPollInterval) {
-      clearInterval(pollTimer);
-      pollTimer = setInterval(pollRemote, targetInterval);
-    }
-  }
-  currentPollInterval = targetInterval;
+  // 应用远程更新
+  localData.value = parsed.content;
+  mode.value = parsed.mode;
+  localUpdatedAt.value = parsed.updatedAt || Date.now();
 };
 
 const handleInputActivity = () => {
   lastInputAt.value = Date.now();
-  updateSyncMode();
-  scheduleBroadcast();
+  // 用户输入时，通过Socket.IO广播更新
+  if (store.isLogged && store.socket) {
+    if (broadcastTimer) clearTimeout(broadcastTimer);
+    broadcastTimer = setTimeout(() => {
+      const payload = buildPayload();
+      store.socket?.emit("memo:update", {
+        token: store.token || localStorage.getItem("flat-nas-token"),
+        widgetId: props.widget.id,
+        content: payload,
+      });
+    }, 300);
+  }
 };
 
 const handleInnerWheel = (e: WheelEvent) => {
@@ -388,56 +399,24 @@ watch(historyVersions, () => {
   if (!exists) selectedVersionId.value = "new";
 });
 
-let pollTimer: ReturnType<typeof setInterval> | null = null;
-let idleCheckTimer: ReturnType<typeof setInterval> | null = null;
-let currentPollInterval = POLL_ACTIVE_INTERVAL;
-const handleVisibilityChange = () => {
-  isPageVisible.value = document.visibilityState === "visible";
-  updateSyncMode();
-};
-const pollRemote = async () => {
-  if (!store.isLogged || !store.isConnected || isEditing.value) return;
-  const id = props.widget.id;
-  if (!id) return;
-  if (import.meta.env.MODE === "test") return;
-  try {
-    const res = await fetch(`/api/widgets/${id}`, { headers: store.getHeaders() });
-    if (!res.ok) return;
-    const data = await res.json();
-    if (data?.data) {
-      applyRemotePayload(data.data);
-    }
-  } catch {
-    return;
-  }
-};
-
 onMounted(() => {
-  updateSyncMode();
-  idleCheckTimer = setInterval(updateSyncMode, 1000);
-  document.addEventListener("visibilitychange", handleVisibilityChange);
   document.addEventListener("pointerdown", handleDocPointerDown);
   refreshVersions();
 });
 
 onUnmounted(() => {
-  if (pollTimer) clearInterval(pollTimer);
-  if (idleCheckTimer) clearInterval(idleCheckTimer);
   if (serverSaveTimer) clearTimeout(serverSaveTimer);
   if (autoSaveTimer) clearTimeout(autoSaveTimer);
   if (broadcastTimer) clearTimeout(broadcastTimer);
-  document.removeEventListener("visibilitychange", handleVisibilityChange);
   document.removeEventListener("pointerdown", handleDocPointerDown);
 });
 
 const handleFocus = () => {
   isEditing.value = true;
-  updateSyncMode();
 };
 
 const handleBlur = () => {
   isEditing.value = false;
-  updateSyncMode();
 };
 
 </script>


### PR DESCRIPTION
实现了带版本控制的 Widget API，并优化了备忘录组件的实时同步机制。

  ### 后端改动

  1. **新增 Widget 版本控制 API** (backend/handlers/widget_version.go)
     - 实现 Last-Write-Wins 策略的 Widget 保存
     - GET /api/widgets/v2/:id - 获取带版本号和时间戳的 Widget - PUT /api/widgets/v2/:id - 保存 Widget 并自动递增版本号 - 使用全局锁防止并发写入冲突 - 保存成功后通过 Socket.IO 广播更新通知

  2. **更新数据模型** (backend/models/models.go) - Widget 结构体新增 `Version` 字段 - Widget 结构体新增 `UpdatedAt` 字段

  3. **注册新路由** (backend/main.go)
     - 注册版本控制 API 路由
     - 标记旧 /api/widgets/:id 为 deprecated

  ### 前端改动

  4. **优化备忘录实时同步** (frontend/src/components/MemoWidget.vue)
     - 移除轮询机制，改用纯 Socket.IO 推送
     - 使用新版本控制 API 保存数据 - 新增 `isSaving` 标志，保存期间忽略远程更新，防止数据被覆盖 - 编辑期间忽略远程更新
